### PR TITLE
Add test.bash

### DIFF
--- a/test.bash
+++ b/test.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This is free and unencumbered software released into the public domain.
+# For more information, please refer to <https://unlicense.org>
+
+set -e
+
+test=makefat-test
+
+cat <<EOF > "$test.go"
+package main
+import "fmt"
+func main() { fmt.Println("Fat binary OK") }
+EOF
+
+GOOS=darwin GOARCH=amd64 go build -o "$test-amd64" "$test.go"
+GOOS=darwin GOARCH=arm64 go build -o "$test-arm64" "$test.go"
+
+if ./makefat "$test" "$test-amd64" "$test-arm64"; then
+   if [ "$(go env GOOS)" = darwin ]; then
+      "./$test" || true
+      rm "$test"
+   else
+      echo "$test built; please try it on MacOS"
+   fi
+fi
+
+rm "$test.go" "$test-amd64" "$test-arm64"


### PR DESCRIPTION
Note: script won't work until Go supports GOARCH=arm64 GOOS=darwin

On a MacOS host, the test fat binary is run and removed; otherwise it's left there for further use.
